### PR TITLE
Fix issue with the NSF API

### DIFF
--- a/src/sam/functions/api/get_awards_crossref/app.rb
+++ b/src/sam/functions/api/get_awards_crossref/app.rb
@@ -42,7 +42,7 @@ module Functions
 
       params = event.fetch('queryStringParameters', {})
       pi_names = params.fetch('pi_names', '')
-      project_num = params.fetch('project', '')
+      project_num = params.fetch('project', '')&.gsub(' ', '+')
       title = params.fetch('keywords', '')
       years = params.fetch('years', (Date.today.year..Date.today.year - 3).to_a.join(','))
       years = years.split(',').map(&:to_i)

--- a/src/sam/functions/api/get_awards_crossref/app.rb
+++ b/src/sam/functions/api/get_awards_crossref/app.rb
@@ -52,7 +52,7 @@ module Functions
                                                                       (years.nil? || years.empty?)
 
       url = "/#{project_num}" unless project_num.nil? || project_num.empty?
-      url = "?#{_prepare_query_string2(funder:, pi_names:, title:, years:)}" if url.nil?
+      url = "?#{_prepare_query_string(funder:, pi_names:, title:, years:)}" if url.nil?
       url = "#{API_BASE_URL}#{url}"
       logger.debug(message: "Calling Crossref Award API: #{url}") if logger.respond_to?(:debug)
 
@@ -135,7 +135,7 @@ module Functions
           end: "#{years.last}-12-31"
         }
         qs += _sanitize_params(str: ',from-awarded-date::start,until-awarded-date::end', params: filter_params)
-        qs += "&mailto:#{ENV.fetch('ADMIN_EMAIL', 'dmptool@ucop.edu')}"
+        qs += "&mailto=#{ENV.fetch('ADMIN_EMAIL', 'dmptool@ucop.edu')}"
         qs
       end
       # rubocop:enable Metrics/AbcSize
@@ -155,6 +155,7 @@ module Functions
         affil = { name: affiliation['name'] }
         affil['affiliation_id'] = affiliation_id unless affiliation_id.nil?
         pi[:dmproadmap_affiliation] = affil
+        pi[:role] = ['http://credit.niso.org/contributor-roles/investigation']
         pi
       end
       # rubocop:enable Metrics/AbcSize

--- a/src/sam/functions/api/get_awards_crossref/app.rb
+++ b/src/sam/functions/api/get_awards_crossref/app.rb
@@ -42,7 +42,7 @@ module Functions
 
       params = event.fetch('queryStringParameters', {})
       pi_names = params.fetch('pi_names', '')
-      project_num = params.fetch('project', '')&.gsub(' ', '+')
+      project_num = URI.encode_www_form_component(params.fetch('project', ''))
       title = params.fetch('keywords', '')
       years = params.fetch('years', (Date.today.year..Date.today.year - 3).to_a.join(','))
       years = years.split(',').map(&:to_i)

--- a/src/sam/functions/api/get_awards_nih/app.rb
+++ b/src/sam/functions/api/get_awards_nih/app.rb
@@ -130,7 +130,7 @@ module Functions
           nm = "#{hash['last_name']}, #{[hash['first_name'], hash['middle_name']].join(' ')}"
         end
 
-        { name: nm, mbox: hash['email'] }
+        { name: nm, mbox: hash['email', role: ['http://credit.niso.org/contributor-roles/investigation']] }
       end
 
       # Transform the NIH API results into our common funder API response

--- a/src/sam/functions/api/get_awards_nsf/app.rb
+++ b/src/sam/functions/api/get_awards_nsf/app.rb
@@ -37,7 +37,7 @@ module Functions
 
       params = event.fetch('queryStringParameters', {})
       pi_names = params.fetch('pi_names', '')
-      project_num = params.fetch('project', '')
+      project_num = params.fetch('project', '')&.gsub(' ', '+')
       title = params.fetch('keywords', '')
       years = params.fetch('years', (Date.today.year..Date.today.year - 3).to_a.join(','))
       years = years.split(',').map(&:to_i)

--- a/src/sam/functions/api/get_awards_nsf/app.rb
+++ b/src/sam/functions/api/get_awards_nsf/app.rb
@@ -37,7 +37,7 @@ module Functions
 
       params = event.fetch('queryStringParameters', {})
       pi_names = params.fetch('pi_names', '')
-      project_num = params.fetch('project', '')&.gsub(' ', '+')
+      project_num = URI.encode_www_form_component(params.fetch('project', ''))
       title = params.fetch('keywords', '')
       years = params.fetch('years', (Date.today.year..Date.today.year - 3).to_a.join(','))
       years = years.split(',').map(&:to_i)
@@ -133,7 +133,7 @@ module Functions
         return [] unless response_body.is_a?(Hash)
 
         response_body.fetch('response', {}).fetch('award', []).map do |award|
-          next if award['title'].nil? || award['id'].nil? || award['piLastName'].nil?
+          next if award['title'].nil? || award['id'].nil? # || award['piLastName'].nil?
 
           date_parts = award.fetch('date', '').split('/')
           {

--- a/src/sam/functions/api/get_awards_nsf/app.rb
+++ b/src/sam/functions/api/get_awards_nsf/app.rb
@@ -102,6 +102,7 @@ module Functions
         end_date = "12/31/#{years.last}"
         qs << _sanitize_params(str: 'dateStart=:start', params: { start: start_date }) unless years.first.nil?
         qs << _sanitize_params(str: 'dateEnd=:end', params: { end: end_date }) unless years.last.nil?
+        qs << 'printFields=pdPIName,piEmail,title,awardee,ueiNumber,cfdaNumber,startDate,expDate,abstractText'
         qs.join('&')
       end
       # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity


### PR DESCRIPTION
- Fixes an issue where we were not properly escaping project numbers sent to the NSF and Crossref awards APIs. Using the core Ruby URI gem to properly encode the values now. We are doing this in a separate function for all other args
- Added the `printField` arg to the NSF query string to tell the NSF API which fields we want back
- Also remove the restriction that the NSF results MUST have a principal investigator (PI) defined