### PR TITLE
Crossref awards API fix and enable backups for Dynamo Table

### DIFF
--- a/config/dev/regional/dynamo.yaml
+++ b/config/dev/regional/dynamo.yaml
@@ -9,13 +9,11 @@ parameters:
 
   SsmPath: !stack_attr sceptre_user_data.ssm_path
 
-  OpenSearchDomain: !stack_output_external Uc3OpsOpensearchStack::domainEndpoint
-
   # Dynamo settings
   #   See: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
   DynamoTableClass: 'STANDARD'
   DynamoEnableContributorInsights: 'true'
-  DynamoEnablePointInTimeRecovery: 'false'
+  DynamoEnablePointInTimeRecovery: 'true'
   DynamoBillingMode: 'PAY_PER_REQUEST'
   DynamoReadCapacityUnits: '8'
   DynamoWriteCapacityUnits: '30'

--- a/config/prd/regional/dynamo.yaml
+++ b/config/prd/regional/dynamo.yaml
@@ -13,7 +13,7 @@ parameters:
   #   See: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
   DynamoTableClass: 'STANDARD'
   DynamoEnableContributorInsights: 'true'
-  DynamoEnablePointInTimeRecovery: 'false'
+  DynamoEnablePointInTimeRecovery: 'true'
   DynamoBillingMode: 'PAY_PER_REQUEST'
   DynamoReadCapacityUnits: '16'
   DynamoWriteCapacityUnits: '60'

--- a/config/stg/regional/config.yaml
+++ b/config/stg/regional/config.yaml
@@ -7,10 +7,6 @@ sceptre_user_data:
     - !stack_output_external cdl-uc3-prd-defaultsubnet-stack::defaultsubnet2a
     - !stack_output_external cdl-uc3-prd-defaultsubnet-stack::defaultsubnet2b
     - !stack_output_external cdl-uc3-prd-defaultsubnet-stack::defaultsubnet2c
-  private_subnets:
-    - !stack_output_external cdl-uc3-prd-privatesubnet-stack::privatesubnet2a
-    - !stack_output_external cdl-uc3-prd-privatesubnet-stack::privatesubnet2b
-    - !stack_output_external cdl-uc3-prd-privatesubnet-stack::privatesubnet2c
 
   hosted_zone: !stack_output_external uc3-ops-aws-prd-route53::HostedZoneIdUc3StgCdlibNet
 

--- a/config/stg/regional/dynamo.yaml
+++ b/config/stg/regional/dynamo.yaml
@@ -13,7 +13,7 @@ parameters:
   #   See: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
   DynamoTableClass: 'STANDARD'
   DynamoEnableContributorInsights: 'true'
-  DynamoEnablePointInTimeRecovery: 'false'
+  DynamoEnablePointInTimeRecovery: 'true'
   DynamoBillingMode: 'PAY_PER_REQUEST'
   DynamoReadCapacityUnits: '8'
   DynamoWriteCapacityUnits: '30'

--- a/src/sam/template.yaml
+++ b/src/sam/template.yaml
@@ -474,7 +474,7 @@ Resources:
       CodeUri: 'functions/api/get_awards_crossref/'
       Handler: 'app.Functions::GetAwardsCrossref.process'
       Runtime: 'ruby3.2'
-      Timeout: 5
+      Timeout: 30
       Architectures:
         - 'x86_64'
       Layers:
@@ -1374,7 +1374,7 @@ Resources:
   LambdaDmpWarmerRule:
     Type: 'AWS::Events::Rule'
     Properties:
-      ScheduleExpression: 'rate(20 minutes)'
+      ScheduleExpression: 'rate(10 minutes)'
       Targets:
         - Id: !Ref DeleteDmpFunction
           Arn: !GetAtt DeleteDmpFunction.Arn
@@ -1432,7 +1432,7 @@ Resources:
   LambdaAwardWarmerRule:
     Type: 'AWS::Events::Rule'
     Properties:
-      ScheduleExpression: 'rate(20 minutes)'
+      ScheduleExpression: 'rate(10 minutes)'
       Targets:
         - Id: !Ref GetAwardsCrossrefApiFunction
           Arn: !GetAtt GetAwardsCrossrefApiFunction.Arn

--- a/templates/dynamo.yaml
+++ b/templates/dynamo.yaml
@@ -13,9 +13,6 @@ Parameters:
   SsmPath:
     Type: 'String'
 
-  # OpenSearchDomain:
-  #   Type: 'String'
-
   DynamoTableClass:
     Type: 'String'
     Default: 'STANDARD'
@@ -253,14 +250,6 @@ Resources:
       Name: !Sub "${SsmPath}DynamoTableName"
       Type: 'String'
       Value: !Select [1, !Split ['/', !GetAtt DynamoTable.Arn]]
-
-  # OpenSearchDomainParameter:
-  #   Type: 'AWS::SSM::Parameter'
-  #   Properties:
-  #     Description: !Sub "${AWS::StackName} OpenSearch Domain"
-  #     Name: !Sub "${SsmPath}OpenSearchDomain"
-  #     Type: 'String'
-  #     Value: !Ref OpenSearchDomain
 
 Outputs:
   # ResourcesDynamoTableName:


### PR DESCRIPTION
- Updates to the Crossref awards API to handle contact/contributor info
- Also turned on PointInTimeRecovery for our DMPs DynamoTable. There is another option to create Replica tables, but the PointInTimeRecovery was easiest to enable at this point. Will need to monitor to see how it impacts cost
- Removed some lines from the AWS CF templates for OpenSearch domain info that is no longer relevant
- Removed the old private subnet references since those resources no longer exist
- Decreased the amount of time for the Lambda warmers 