### PR TITLE
Fix for the NSF awards API

### DIFF
--- a/src/sam/functions/api/get_awards_nsf/app.rb
+++ b/src/sam/functions/api/get_awards_nsf/app.rb
@@ -136,7 +136,7 @@ module Functions
         return [] unless response_body.is_a?(Hash)
 
         response_body.fetch('response', {}).fetch('award', []).map do |award|
-          next if award['title'].nil? || award['id'].nil? || award['pdPIName'].nil?
+          next if award['title'].nil? || award['id'].nil?
 
           start_parts = award.fetch('startDate', '').split('/')
           end_parts = award.fetch('expDate', '').split('/')


### PR DESCRIPTION
Minor adjustment to the logic that parses the results from the NSF awards API to allow results with no PI to be included in the results