### PR TITLE
Fix issue with NSF API

### DIFF
--- a/src/sam/functions/api/get_awards_nsf/app.rb
+++ b/src/sam/functions/api/get_awards_nsf/app.rb
@@ -46,7 +46,7 @@ module Functions
                                                                       (pi_names.nil? || pi_names.empty?) &&
                                                                       (years.nil? || years.empty?)
 
-      url = API_BASE_URL.gsub('.json', "/#{project_num}.json") unless project_num.nil? || project_num.empty?
+      url = API_BASE_URL.gsub('.json', "/#{project_num}.json?#{_print_fields}") unless project_num.nil? || project_num.empty?
       url = "#{API_BASE_URL}?#{_prepare_query_string(pi_names:, title:, years:)}" if url.nil?
 
       logger.info(message: "Calling NSF Api: #{url}") if logger.respond_to?(:debug)
@@ -104,10 +104,14 @@ module Functions
         end_date = "12/31/#{years.last}"
         qs << _sanitize_params(str: 'dateStart=:start', params: { start: start_date }) unless years.first.nil?
         qs << _sanitize_params(str: 'dateEnd=:end', params: { end: end_date }) unless years.last.nil?
-        qs << 'printFields=id,pdPIName,piEmail,title,awardee,ueiNumber,startDate,expDate,abstractText,fundsObligatedAmt'
+        qs << _print_fields
         qs.join('&')
       end
       # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+
+      def _print_fields
+        'printFields=id,pdPIName,piEmail,title,awardee,ueiNumber,startDate,expDate,abstractText,fundsObligatedAmt'
+      end
 
       # Transform the NSF API results into our common funder API response
       #


### PR DESCRIPTION
Here is the query we run if the user provides an NSF award number: https://www.research.gov/awardapi-service/v1/awards/2332353.json

Here is the query we run when the user provides info in the other fields (title, PIs, year): https://www.research.gov/awardapi-service/v1/awards.json?pdPIName=praetzellis&dateStart=01%2F01%2F2023&dateEnd=12%2F31%2F2023&printFields=id,pdPIName,piEmail,title,awardee,ueiNumber,startDate,expDate,abstractText,fundsObligatedAmt

Note that the first does not include the `printFields` parameter and so it doesn't return the contact info or the abstract. This PR adds that parameter to the first scenario so that we get the same results back

@jupiter007 can you check the logic in the React page to make sure that if no contributor information is returned that it will not create an empty contributor record? I think that is why Maria was seeing an entry that just had a role of 'other' and nothing else.