### PR TITLE
Switched SSM resolvers for Sceptre configs

### DIFF
--- a/config/dev/global/cert.yaml
+++ b/config/dev/global/cert.yaml
@@ -3,7 +3,7 @@ template:
   type: file
 
 parameters:
-  # HostedZoneId: !ssm_parameter /uc3/dmp/hub/dev/HostedZoneId
+  # HostedZoneId: !ssm /uc3/dmp/hub/dev/HostedZoneId
   HostedZoneId: !stack_attr sceptre_user_data.hosted_zone
 
   Domain: !stack_attr sceptre_user_data.domain

--- a/config/dev/global/config.yaml
+++ b/config/dev/global/config.yaml
@@ -6,5 +6,5 @@ region: 'us-east-1'
 sceptre_user_data:
   env: 'dev'
   domain: 'dmphub.uc3dev.cdlib.net'
-  hosted_zone: !ssm_parameter /uc3/dmp/hub/dev/HostedZoneId
+  hosted_zone: !ssm /uc3/dmp/hub/dev/HostedZoneId
   ssm_path: '/uc3/dmp/hub/dev/'

--- a/config/dev/regional/config.yaml
+++ b/config/dev/regional/config.yaml
@@ -17,7 +17,7 @@ sceptre_user_data:
   public_subnet_c: !stack_output_external cdl-uc3-dev-defaultsubnet-stack::defaultsubnet2c
 
   # hosted_zone_id: !stack_output_external uc3-ops-dmphub-dev-route53::HostedZoneId
-  hosted_zone_id: !ssm_parameter /uc3/dmp/hub/dev/HostedZoneId
+  hosted_zone_id: !ssm /uc3/dmp/hub/dev/HostedZoneId
 
   env: 'dev'
   domain: 'dmphub.uc3dev.cdlib.net'

--- a/config/dev/regional/sqs.yaml
+++ b/config/dev/regional/sqs.yaml
@@ -8,7 +8,7 @@ dependencies:
 parameters:
   Env: !stack_attr sceptre_user_data.env
   SsmPath: !stack_attr sceptre_user_data.ssm_path
-  AdminEmail: !ssm_parameter /uc3/dmp/hub/dev/AdminEmail
+  AdminEmail: !ssm /uc3/dmp/hub/dev/AdminEmail
 
   # SQS settings
   #   See: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sqs-queue.html

--- a/config/prd/config.yaml
+++ b/config/prd/config.yaml
@@ -15,4 +15,4 @@ stack_tags:
   Contact: 'briley'
 
 # In the cdl-uc3-prd account devs must call cloudformation using a service role
-cloudformation_service_role: !ssm_parameter /uc3/prd/CfnServiceRoleArn
+cloudformation_service_role: !ssm /uc3/prd/CfnServiceRoleArn

--- a/config/prd/global/config.yaml
+++ b/config/prd/global/config.yaml
@@ -6,5 +6,5 @@ region: 'us-east-1'
 sceptre_user_data:
   env: 'prd'
   domain: 'dmphub.uc3prd.cdlib.net'
-  hosted_zone: !ssm_parameter /uc3/dmp/hub/prd/HostedZoneId
+  hosted_zone: !ssm /uc3/dmp/hub/prd/HostedZoneId
   ssm_path: '/uc3/dmp/hub/prd/'

--- a/config/prd/regional/backup-vault.yaml
+++ b/config/prd/regional/backup-vault.yaml
@@ -8,5 +8,5 @@ parameters:
 
   Env: !stack_attr sceptre_user_data.env
 
-  MainAccountId: !ssm_parameter /uc3/MainAccountId
-  MainAccountBackupVaultArn: !ssm_parameter /uc3/MainAccountBackupVault
+  MainAccountId: !ssm /uc3/MainAccountId
+  MainAccountBackupVaultArn: !ssm /uc3/MainAccountBackupVault

--- a/config/prd/regional/config.yaml
+++ b/config/prd/regional/config.yaml
@@ -14,7 +14,7 @@ sceptre_user_data:
   public_subnet_b: !stack_output_external cdl-uc3-prd-defaultsubnet-stack::defaultsubnet2b
   public_subnet_c: !stack_output_external cdl-uc3-prd-defaultsubnet-stack::defaultsubnet2c
 
-  hosted_zone: !ssm_parameter /uc3/dmp/hub/prd/HostedZoneId
+  hosted_zone: !ssm /uc3/dmp/hub/prd/HostedZoneId
 
   env: 'prd'
   domain: 'dmphub.uc3prd.cdlib.net'

--- a/config/prd/regional/sqs.yaml
+++ b/config/prd/regional/sqs.yaml
@@ -8,7 +8,7 @@ dependencies:
 parameters:
   Env: !stack_attr sceptre_user_data.env
   SsmPath: !stack_attr sceptre_user_data.ssm_path
-  AdminEmail: !ssm_parameter /uc3/dmp/hub/prd/AdminEmail
+  AdminEmail: !ssm /uc3/dmp/hub/prd/AdminEmail
 
   # SQS settings
   #   See: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sqs-queue.html

--- a/config/stg/config.yaml
+++ b/config/stg/config.yaml
@@ -14,4 +14,4 @@ stack_tags:
   Contact: 'briley'
 
 # In the cdl-uc3-prd account devs must call cloudformation using a service role
-cloudformation_service_role:  !ssm_parameter /uc3/prd/CfnServiceRoleArn
+cloudformation_service_role:  !ssm /uc3/prd/CfnServiceRoleArn

--- a/config/stg/global/config.yaml
+++ b/config/stg/global/config.yaml
@@ -6,5 +6,5 @@ region: 'us-east-1'
 sceptre_user_data:
   env: 'stg'
   domain: 'dmphub.uc3stg.cdlib.net'
-  hosted_zone: !ssm_parameter /uc3/dmp/hub/stg/HostedZoneId
+  hosted_zone: !ssm /uc3/dmp/hub/stg/HostedZoneId
   ssm_path: '/uc3/dmp/hub/stg/'

--- a/config/stg/regional/backup-vault.yaml
+++ b/config/stg/regional/backup-vault.yaml
@@ -8,5 +8,5 @@ parameters:
 
   Env: !stack_attr sceptre_user_data.env
 
-  MainAccountId: !ssm_parameter /uc3/MainAccountId
-  MainAccountBackupVaultArn: !ssm_parameter /uc3/MainAccountBackupVault
+  MainAccountId: !ssm /uc3/MainAccountId
+  MainAccountBackupVaultArn: !ssm /uc3/MainAccountBackupVault

--- a/config/stg/regional/sqs.yaml
+++ b/config/stg/regional/sqs.yaml
@@ -8,7 +8,7 @@ dependencies:
 parameters:
   Env: !stack_attr sceptre_user_data.env
   SsmPath: !stack_attr sceptre_user_data.ssm_path
-  AdminEmail: !ssm_parameter /uc3/dmp/hub/stg/AdminEmail
+  AdminEmail: !ssm /uc3/dmp/hub/stg/AdminEmail
 
   # SQS settings
   #   See: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sqs-queue.html


### PR DESCRIPTION
Fixes #152
Switched all use of our homegrown `!ssm_parameter` resolver to the [community managed](https://github.com/Sceptre/sceptre-ssm-resolver) `!ssm` one