### PR TITLE
Feature/add jwt secret

### DIFF
--- a/config/dev/global/dmsp-frontend-route53.yaml
+++ b/config/dev/global/dmsp-frontend-route53.yaml
@@ -3,7 +3,7 @@ template:
   type: 'file'
 
 parameters:
-  HostedZoneId: !ssm_parameter /uc3/dmp/hub/dev/HostedZoneId
+  HostedZoneId: !stack_attr sceptre_user_data.hosted_zone
 
   Domain: 'ui.dmphub.uc3dev.cdlib.net'
   RecordType: 'A'

--- a/config/dev/regional/chatbot.yaml
+++ b/config/dev/regional/chatbot.yaml
@@ -3,7 +3,7 @@ template:
   type: 'file'
 
 parameters:
-  SlackCodestarConnectionArnParameter: !ssm_parameter '/uc3/dmp/hub/dev/SlackCodestarConnection'
+  SlackCodestarConnectionArnParameter: !ssm '/uc3/dmp/hub/dev/SlackCodestarConnection'
   LoggingLevelParameter: 'ERROR'
   SlackChannelIdParameter: C074WLW59EF
   SlackWorkspaceIdParameter: T02AJMWEJ

--- a/config/dev/regional/codebuild-backend.yaml
+++ b/config/dev/regional/codebuild-backend.yaml
@@ -23,7 +23,7 @@ parameters:
   S3ArtifactBucketArn: !stack_output dev/regional/s3.yaml::S3PrivateBucketArn
   S3ArtifactBucketId: !stack_output dev/regional/s3.yaml::S3PrivateBucketId
 
-  CodeStarConnectionArn: !ssm_parameter /uc3/CodeStarConnectionArn
+  CodeStarConnectionArn: !ssm /uc3/CodeStarConnectionArn
 
   # DbSecurityGroupId: !stack_output dev/regional/rds.yaml::DbSecurityGroupId
 
@@ -33,8 +33,8 @@ parameters:
   DbHost: !stack_output dev/regional/rds.yaml::DbAddress
   DbPort: !stack_output dev/regional/rds.yaml::DbPort
   DbName: !stack_output dev/regional/rds.yaml::DbName
-  DbUsername: !ssm_parameter /uc3/dmp/hub/dev/DbUsername
-  DbPassword: !ssm_parameter /uc3/dmp/hub/dev/DbPassword
+  DbUsername: !ssm /uc3/dmp/hub/dev/DbUsername
+  DbPassword: !ssm /uc3/dmp/hub/dev/DbPassword
 
   AppName: !stack_attr sceptre_user_data.backend_server_container_name
 

--- a/config/dev/regional/codebuild-frontend.yaml
+++ b/config/dev/regional/codebuild-frontend.yaml
@@ -22,7 +22,7 @@ parameters:
   S3ArtifactBucketArn: !stack_output dev/regional/s3.yaml::S3PrivateBucketArn
   S3ArtifactBucketId: !stack_output dev/regional/s3.yaml::S3PrivateBucketId
 
-  CodeStarConnectionArn: !ssm_parameter /uc3/CodeStarConnectionArn
+  CodeStarConnectionArn: !ssm /uc3/CodeStarConnectionArn
 
   DbSecurityGroupId: !stack_output dev/regional/rds.yaml::DbSecurityGroupId
   DbPort: !stack_output dev/regional/rds.yaml::DbPort

--- a/config/dev/regional/codepipeline-backend.yaml
+++ b/config/dev/regional/codepipeline-backend.yaml
@@ -3,7 +3,7 @@ template:
   type: 'file'
 
 parameters:
-  CodeStarConnectionArn: !ssm_parameter /uc3/CodeStarConnectionArn
+  CodeStarConnectionArn: !ssm /uc3/CodeStarConnectionArn
 
   S3ArtifactBucketId: !stack_output dev/regional/s3.yaml::S3PrivateBucketId
 

--- a/config/dev/regional/codepipeline-frontend.yaml
+++ b/config/dev/regional/codepipeline-frontend.yaml
@@ -3,7 +3,7 @@ template:
   type: 'file'
 
 parameters:
-  CodeStarConnectionArn: !ssm_parameter /uc3/CodeStarConnectionArn
+  CodeStarConnectionArn: !ssm /uc3/CodeStarConnectionArn
 
   S3ArtifactBucketId: !stack_output dev/regional/s3.yaml::S3PrivateBucketId
 

--- a/config/dev/regional/ecs-backend.yaml
+++ b/config/dev/regional/ecs-backend.yaml
@@ -38,16 +38,20 @@ parameters:
   CognitoClientId: !stack_output dev/regional/cognito.yaml::DmspUserPoolClientId
   CognitoClientSecret: !stack_output dev/regional/cognito.yaml::DmspUserPoolClientSecret
 
-  DmpIdBaseUrl: !ssm_parameter /uc3/dmp/hub/dev/EzidBaseUrl
-  DmpIdShoulder: !ssm_parameter /uc3/dmp/hub/dev/EzidShoulder
+  DmpIdBaseUrl: !ssm /uc3/dmp/hub/dev/EzidBaseUrl
+  DmpIdShoulder: !ssm /uc3/dmp/hub/dev/EzidShoulder
+
+  RestDataSourceCacheTtl: '180'
+  JwtSecret: !ssm /uc3/dmp/tool/dev/JWTSecret
+  JwtTtl: '1hr'
 
   DbConnectionLimit: '5'
   DbHost: !stack_output dev/regional/rds.yaml::DbAddress
   DbPort: !stack_output dev/regional/rds.yaml::DbPort
   DbName: !stack_output dev/regional/rds.yaml::DbName
-  DbUsername: !ssm_parameter /uc3/dmp/hub/dev/DbUsername
-  DbPassword: !ssm_parameter /uc3/dmp/hub/dev/DbPassword
+  DbUsername: !ssm /uc3/dmp/hub/dev/DbUsername
+  DbPassword: !ssm /uc3/dmp/hub/dev/DbPassword
 
-  HelpdeskEmail: !ssm_parameter /uc3/dmsp/prototype/dev/HelpdeskEmail
+  HelpdeskEmail: !ssm /uc3/dmsp/prototype/dev/HelpdeskEmail
 
   UseMockData: 'true'

--- a/config/dev/regional/ecs-frontend.yaml
+++ b/config/dev/regional/ecs-frontend.yaml
@@ -40,4 +40,6 @@ parameters:
 
   LogLevel: 'debug'
 
-  HelpdeskEmail: !ssm_parameter /uc3/dmsp/prototype/dev/HelpdeskEmail
+  JwtSecret: !ssm /uc3/dmp/tool/dev/JWTSecret
+
+  HelpdeskEmail: !ssm /uc3/dmsp/prototype/dev/HelpdeskEmail

--- a/config/dev/regional/ecs-frontend.yaml
+++ b/config/dev/regional/ecs-frontend.yaml
@@ -40,6 +40,9 @@ parameters:
 
   LogLevel: 'debug'
 
+  NextPublicBaseUrl: ="https://ui.dmphub.uc3dev.cdlib.net"
+  NextPublicServerEndpoint: ="https://ui.dmphub.uc3dev.cdlib.net"
+  NextPublicGraphqlServerEndpoint: ="https://ui.dmphub.uc3dev.cdlib.net/graphql"
   JwtSecret: !ssm /uc3/dmp/tool/dev/JWTSecret
 
   HelpdeskEmail: !ssm /uc3/dmsp/prototype/dev/HelpdeskEmail

--- a/config/dev/regional/rds.yaml
+++ b/config/dev/regional/rds.yaml
@@ -32,5 +32,5 @@ parameters:
 
   DbName: 'dmsp'
   DbMasterUsername: 'root'
-  DbMasterPassword: !ssm_parameter /uc3/dmp/hub/dev/DbPassword
+  DbMasterPassword: !ssm /uc3/dmp/hub/dev/DbPassword
   DbPort: '3306'

--- a/initial_setup.rb
+++ b/initial_setup.rb
@@ -18,10 +18,14 @@ OptionParser.new do |parser|
   parser.on("-s", "--ezid-shoulder SHOULDER", "Your EZID DOI shoulder") { |s| @opts[:ezid_shoulder] = s }
   parser.on("-u", "--ezid-username USER", "Your EZID username") { |u| @opts[:ezid_user] = u }
   parser.on("-p", "--ezid-password PWD", "Your EZID password") { |p| @opts[:ezid_pwd] = p }
+  parser.on("-j", "--jwt-secret JWT_SECRET", "The DMPTool JSON Web Token Secret") { |p| @opts[:jwt_secret] = p }
 end.parse!
 
 def put_param(key:, val:, secure: false, override: false)
-  name = "/uc3/dmp/hub/#{@opts[:env]}/#{key}"
+  dmptool_vals = %w[JWTSecret]
+  service = dmptool_vals.include?(key) ? 'tool' : 'hub'
+  name = "/uc3/dmp/#{service}/#{@opts[:env]}/#{key}"
+
   args = [
     "--region #{@opts[:region]}",
     "--name #{name}",
@@ -55,6 +59,8 @@ if @opts.length > 3 && !@opts[:env].nil?
   put_param(key: 'EzidShoulder', val: @opts[:ezid_shoulder], secure: true) unless @opts[:ezid_shoulder].nil?
   put_param(key: 'EzidUsername', val: @opts[:ezid_user], secure: true) unless @opts[:ezid_user].nil?
   put_param(key: 'EzidPassword', val: @opts[:ezid_pwd], secure: true) unless @opts[:ezid_pwd].nil?
+
+  put_param(key: 'JWTSecret', val: @opts[:jwt_secret], secure: true) unless @opts[:jwt_secret].nil?
 else
   puts 'You must specify the environment and one or more options! Run `ruby initial_setup -h` for more info.'
 end

--- a/templates/alb.yaml
+++ b/templates/alb.yaml
@@ -213,12 +213,34 @@ Resources:
         - Field: 'path-pattern'
           PathPatternConfig:
             Values:
+              # NextJS support
               - '/graphql'
-              - '/auth'
-              - '/token'
-              - '/up'
+              - '/apollo-signin'
+              - '/apollo-signout'
+              - '/apollo-signup'
       ListenerArn: !GetAtt AlbListenerHttps.ListenerArn
       Priority: 1
+
+  # Listener rule to send traffic to certain paths to the Apollo server backend
+  ApolloServerListenerRule2:
+    Type: 'AWS::ElasticLoadBalancingV2::ListenerRule'
+    Properties:
+      Actions:
+        - Type: 'forward'
+          TargetGroupArn: !Ref ApolloServerTargetGroup
+      Conditions:
+        - Field: 'path-pattern'
+          PathPatternConfig:
+            Values:
+              # ALB healthcheck
+              - '/up'
+
+              # OAuth2 support
+              - '/apollo-authenticate'
+              - '/apollo-authorize'
+              - '/apollo-token'
+      ListenerArn: !GetAtt AlbListenerHttps.ListenerArn
+      Priority: 5 # Big jump here. CF won't allow you to reorder and add additional at the same time
 
   # Listener rule to send traffic to certain paths to the Apollo server backend
   NextJsServerListenerRule:
@@ -233,7 +255,7 @@ Resources:
             Values:
               - '/healthcheck'
       ListenerArn: !GetAtt AlbListenerHttps.ListenerArn
-      Priority: 2
+      Priority: 10 # Big jump here. CF won't allow you to reorder and add additional at the same time
 
   # TODO: Add the listener rule to send traffic to Shibboleth
 

--- a/templates/cognito.yaml
+++ b/templates/cognito.yaml
@@ -276,28 +276,6 @@ Resources:
       # The length of time the user can refresh their token
       RefreshTokenValidity: !Ref RefreshTokenValidity
 
-  # New ReactJS UI Client
-  #    WARNING: Changes to this Client may result in a new Client Id/Secret. If so, you will need to
-  #             update the SSM params in `/uc3/dmp/hub/${Env}/DmspClient[Id/Secret]`
-  #             You will also need to inform the ReactJS admin of the change.
-  DmspUserPoolClient:
-    Type: 'AWS::Cognito::UserPoolClient'
-    #DeletionPolicy: Retain
-    Properties:
-      ClientName: !Sub '${AWS::StackName}-dmsp-ui'
-      UserPoolId: !Ref UserPool
-      GenerateSecret: true
-      AllowedOAuthFlowsUserPoolClient: true
-      AllowedOAuthFlows:
-        - 'code'
-      AllowedOAuthScopes:
-        - 'email'
-        - 'openid'
-      CallbackURLs: !Ref DmspUiCallbackUrls
-      LogoutURLs: !Ref DmspLogoutUrls
-      SupportedIdentityProviders:
-        - 'COGNITO'
-
   # -----------------------------------------------------------
   # Route53 - DNS configuration
   #   See: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/AWS_Route53.html
@@ -330,10 +308,10 @@ Outputs:
       Name: !Sub '${Env}-CognitoUserPoolArn'
 
   DmspUserPoolClientId:
-    Value: !Ref DmspUserPoolClient
+    Value: !Ref UiUserPoolClient
 
   DmspUserPoolClientSecret:
-    Value: !GetAtt DmspUserPoolClient.ClientSecret
+    Value: !GetAtt UiUserPoolClient.ClientSecret
 
   # DmspUserPoolclientUrl:
   #   Value: !Sub 'https://${Subdomain}.${Domain}.${AWS::Region}.amazoncognito.com/login?response_type=code&client_id=${DmspUserPoolClient}&redirect_uri=${DmspUiRedirectUrl}'

--- a/templates/ecs-backend.yaml
+++ b/templates/ecs-backend.yaml
@@ -91,6 +91,17 @@ Parameters:
   DmpIdShoulder:
     Type: 'String'
 
+  RestDataSourceCacheTtl:
+    Type: 'Number'
+    Default: 180
+
+  JwtSecret:
+    Type: 'String'
+
+  JwtTtl:
+    Type: 'String'
+    Default: '1hr'
+
   DbConnectionLimit:
     Type: 'Number'
     Default: 5
@@ -208,10 +219,19 @@ Resources:
             - ContainerPort: !Ref DbPort
               Protocol: 'tcp'
           Environment:
+            - Name: 'APP_ENV'
+              Value: !Ref AppEnv
             - Name: 'LOG_LEVEL'
               Value: !Ref LogLevel
             - Name: 'USE_MOCK_DATA'
               Value: !Ref UseMockData
+
+            - Name: 'REST_DATA_SOURCE_CACHE_TTL'
+              Value: !Ref RestDataSourceCacheTtl
+            - Name: 'JWT_SECRET'
+              Value: !Ref JwtSecret
+            - Name: 'JWT_TTL'
+              Value: !Ref JwtTtl
 
             - Name: 'DMP_ID_BASE_URL'
               Value: !Ref DmpIdBaseUrl

--- a/templates/ecs-backend.yaml
+++ b/templates/ecs-backend.yaml
@@ -219,8 +219,6 @@ Resources:
             - ContainerPort: !Ref DbPort
               Protocol: 'tcp'
           Environment:
-            - Name: 'APP_ENV'
-              Value: !Ref AppEnv
             - Name: 'LOG_LEVEL'
               Value: !Ref LogLevel
             - Name: 'USE_MOCK_DATA'

--- a/templates/ecs-frontend.yaml
+++ b/templates/ecs-frontend.yaml
@@ -33,6 +33,15 @@ Parameters:
     Type: 'Number'
     Default: 4000
 
+  NextPublicBaseUrl:
+    Type: 'String'
+
+  NextPublicServerEndpoint:
+    Type: 'String'
+
+  NextPublicGraphqlServerEndpoint:
+    Type: 'String'
+
   JwtSecret:
     Type: 'String'
 
@@ -174,6 +183,12 @@ Resources:
               Value: !Ref LogLevel
             - Name: 'JWT_SECRET'
               Value: !Ref JwtSecret
+            - Name: 'NEXT_PUBLIC_BASE_URL'
+              Value: !Ref NextPublicBaseUrl
+            - Name: 'NEXT_PUBLIC_SERVER_ENDPOINT'
+              Value: !Ref NextPublicServerEndpoint
+            - Name: 'NEXT_PUBLIC_GRAPHQL_SERVER_ENDPOINT'
+              Value: !Ref NextPublicGraphqlServerEndpoint
 
   # Container Service definition
   EcsService:

--- a/templates/ecs-frontend.yaml
+++ b/templates/ecs-frontend.yaml
@@ -33,6 +33,9 @@ Parameters:
     Type: 'Number'
     Default: 4000
 
+  JwtSecret:
+    Type: 'String'
+
   EcsDesiredServiceCount:
     Type: 'Number'
     Default: 1
@@ -169,6 +172,8 @@ Resources:
           Environment:
             - Name: 'LOG_LEVEL'
               Value: !Ref LogLevel
+            - Name: 'JWT_SECRET'
+              Value: !Ref JwtSecret
 
   # Container Service definition
   EcsService:


### PR DESCRIPTION
Fixes [AWS issue #71](https://github.com/CDLUC3/dmsp_backend_prototype/issues/71)
A step toward #153 by placing the JWTSecret in SSM

- Discovered that we worked on #152 in the main account but did not update all of the new Sceptre configs in development, so  switched all instances of `!ssm_parameter` to `!ssm`
- Added new ENV variable to ecs-backend 
- Added new ENV variable to ecs-frontend 
- Updated Wiki Installation page and ruby helper script with instructions on how to add JWTSecret to SSM
- Updated ALB template to use new Apollo Server endpoints (there is a limit of 10 paths per listener rule, so had to add an additional one)
- Removed an old unused Cognito client (added when we tested out using Cognito for UI auth)
- Updated the Cognito Outputs to export the correct credentials for the Apollo Server 
- 