### PR TITLE
Support for a Redis cache for the DMPTool backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changle Log
 
+### Added
+- `redis.yaml` Elasticache template
+- `redis-backend.yaml` Sceptre config
+- Session Manager policies for `ecs-frontend` and `ecs-backend` so that we can connect to containers
+
+### Updated
+- Updated the `ecs-backend.yaml` Sceptre config and template to include the Elasticache Host and Port and also a bunch of new bcrypt, crypto, NODE_ENV and jwt ENV variables
+- Updated the `ecs-cluster.yaml` so that it has the Redis port and attaches to the Redis Security Group
+- Updated the `ecs-backend.yaml` and `ecs-frontend.yaml` to have a minimum of 2 containers
+- Updated the `initial_setup.rb` script so that the JWT refresh token secret and Cache hash secret can be specified (updated the Wiki documentation as well)
+- Updated the `alb.yaml` with the new refresh, signout and csrf backend endpoints
+
 ## v1.4.4
 
 ### Added

--- a/config/dev/regional/cloud9-bastion.yaml
+++ b/config/dev/regional/cloud9-bastion.yaml
@@ -7,10 +7,6 @@ parameters:
 
   SubnetId: !stack_attr sceptre_user_data.public_subnet_a
 
-  DbSecurityGroupId: !stack_output dev/regional/rds.yaml::DbSecurityGroupId
-
-  DbPort: !stack_output dev/regional/rds.yaml::DbPort
-
   IdleTimeoutMinutes: '15'
 
   ImageId: 'amazonlinux-2023-x86_64'

--- a/config/dev/regional/ecs-backend.yaml
+++ b/config/dev/regional/ecs-backend.yaml
@@ -48,12 +48,12 @@ parameters:
   NodeEnv: 'staging'
 
   JwtSecret: !ssm /uc3/dmp/tool/dev/JWTSecret
-  JwtTtl: '600' # 10 minutes
+  JwtTtl: '600000' # 10 minutes (in milliseconds)
   JwtRefreshSecret: !ssm /uc3/dmp/tool/dev/JWTRefreshSecret
-  JwtRefreshTtl: '86400' # 1 day
+  JwtRefreshTtl: '86400000' # 1 day (in milliseconds)
 
-  CsrfLength: '32'
-  CsrfTtl: '3600' # 1 hour
+  CsrfLength: '64'
+  CsrfTtl: '3600' # 1 hour (in seconds)
 
   DbConnectionLimit: '5'
   DbHost: !stack_output dev/regional/rds.yaml::DbAddress

--- a/config/dev/regional/ecs-backend.yaml
+++ b/config/dev/regional/ecs-backend.yaml
@@ -9,7 +9,7 @@ parameters:
 
   AppName: !stack_attr sceptre_user_data.backend_server_container_name
 
-  EcsDesiredServiceCount: '1'
+  EcsDesiredServiceCount: '2'
 
   AppPort: '4000'
 
@@ -30,7 +30,7 @@ parameters:
 
   StartTimeout: '30'
   HealthCheckGracePeriod: '30'
-  MinimumHealthyContainerPercentage: '100'
+  MinimumHealthyContainerPercentage: '50'
   MaximumHealthyContainerPercentage: '200'
   StopTimeout: '30'
 
@@ -41,9 +41,19 @@ parameters:
   DmpIdBaseUrl: !ssm /uc3/dmp/hub/dev/EzidBaseUrl
   DmpIdShoulder: !ssm /uc3/dmp/hub/dev/EzidShoulder
 
-  RestDataSourceCacheTtl: '180'
+  BcryptSaltRounds: '10'
+  HashTokenSecret: !ssm /uc3/dmp/tool/dev/CacheHashSecret
+  RestDataSourceCacheTtl: '180' # 2 minutes
+
+  NodeEnv: 'staging'
+
   JwtSecret: !ssm /uc3/dmp/tool/dev/JWTSecret
-  JwtTtl: '1hr'
+  JwtTtl: '600' # 10 minutes
+  JwtRefreshSecret: !ssm /uc3/dmp/tool/dev/JWTRefreshSecret
+  JwtRefreshTtl: '86400' # 1 day
+
+  CsrfLength: '32'
+  CsrfTtl: '3600' # 1 hour
 
   DbConnectionLimit: '5'
   DbHost: !stack_output dev/regional/rds.yaml::DbAddress
@@ -51,6 +61,10 @@ parameters:
   DbName: !stack_output dev/regional/rds.yaml::DbName
   DbUsername: !ssm /uc3/dmp/hub/dev/DbUsername
   DbPassword: !ssm /uc3/dmp/hub/dev/DbPassword
+
+  CacheHost: !stack_output dev/regional/redis-backend.yaml::RedisReaderHost
+  CachePort: !stack_output dev/regional/redis-backend.yaml::RedisReaderPort
+  CacheConnectTimeout: '10000' # 10 seconds
 
   HelpdeskEmail: !ssm /uc3/dmsp/prototype/dev/HelpdeskEmail
 

--- a/config/dev/regional/ecs-cluster.yaml
+++ b/config/dev/regional/ecs-cluster.yaml
@@ -9,6 +9,8 @@ parameters:
 
   DbSecurityGroupId: !stack_output dev/regional/rds.yaml::DbSecurityGroupId
 
-  DbHost: !stack_output dev/regional/rds.yaml::DbAddress
+  CacheSecurityGroupId: !stack_output dev/regional/redis-backend.yaml::RedisCacheSecurityGroupID
 
   DbPort: !stack_output dev/regional/rds.yaml::DbPort
+
+  CachePort: !stack_output dev/regional/redis-backend.yaml::RedisReaderPort

--- a/config/dev/regional/redis-backend.yaml
+++ b/config/dev/regional/redis-backend.yaml
@@ -1,0 +1,12 @@
+template:
+  path: 'redis.yaml'
+  type: 'file'
+
+parameters:
+  VpcId: !stack_attr sceptre_user_data.vpc_id
+
+  Subnets: !stack_attr sceptre_user_data.public_subnets
+
+  Env: !stack_attr sceptre_user_data.env
+
+  CachePort: '6379'

--- a/initial_setup.rb
+++ b/initial_setup.rb
@@ -18,7 +18,9 @@ OptionParser.new do |parser|
   parser.on("-s", "--ezid-shoulder SHOULDER", "Your EZID DOI shoulder") { |s| @opts[:ezid_shoulder] = s }
   parser.on("-u", "--ezid-username USER", "Your EZID username") { |u| @opts[:ezid_user] = u }
   parser.on("-p", "--ezid-password PWD", "Your EZID password") { |p| @opts[:ezid_pwd] = p }
-  parser.on("-j", "--jwt-secret JWT_SECRET", "The DMPTool JSON Web Token Secret") { |p| @opts[:jwt_secret] = p }
+  parser.on("-c", "--cache-secret JWT_SECRET", "The secret used by the DMPTool backend for hashing tokens before they're stored in the cache") { |c| @opts[:cache_secret] = c }
+  parser.on("-j", "--jwt-secret JWT_SECRET", "The JSON Web Token secret used by the DMPTool frontend and backend for access tokens") { |p| @opts[:jwt_secret] = p }
+  parser.on("-x", "--jwt-refresh-secret JWT_REFRESH_SECRET", "The JSON Web Token secret used by the DMPTool frontend and backend for refresh tokens") { |x| @opts[:jwt_refresh_secret] = x }
 end.parse!
 
 def put_param(key:, val:, secure: false, override: false)
@@ -60,7 +62,9 @@ if @opts.length > 3 && !@opts[:env].nil?
   put_param(key: 'EzidUsername', val: @opts[:ezid_user], secure: true) unless @opts[:ezid_user].nil?
   put_param(key: 'EzidPassword', val: @opts[:ezid_pwd], secure: true) unless @opts[:ezid_pwd].nil?
 
+  put_param(key: 'CacheHashSecret', val: @opts[:cache_secret], secure: true) unless @opts[:cache_secret].nil?
   put_param(key: 'JWTSecret', val: @opts[:jwt_secret], secure: true) unless @opts[:jwt_secret].nil?
+  put_param(key: 'JWTRefreshSecret', val: @opts[:jwt_refresh_secret], secure: true) unless @opts[:jwt_refresh_secret].nil?
 else
   puts 'You must specify the environment and one or more options! Run `ruby initial_setup -h` for more info.'
 end

--- a/templates/alb.yaml
+++ b/templates/alb.yaml
@@ -215,6 +215,7 @@ Resources:
             Values:
               # NextJS support
               - '/graphql'
+              - '/apollo-refresh'
               - '/apollo-signin'
               - '/apollo-signout'
               - '/apollo-signup'
@@ -235,10 +236,8 @@ Resources:
               # ALB healthcheck
               - '/up'
 
-              # OAuth2 support
-              - '/apollo-authenticate'
-              - '/apollo-authorize'
-              - '/apollo-token'
+              # CSRF support for `/apollo-*` endpoints
+              - '/apollo-csrf'
       ListenerArn: !GetAtt AlbListenerHttps.ListenerArn
       Priority: 5 # Big jump here. CF won't allow you to reorder and add additional at the same time
 

--- a/templates/cloud9-bastion.yaml
+++ b/templates/cloud9-bastion.yaml
@@ -9,13 +9,6 @@ Parameters:
   VpcId:
     Type: 'AWS::EC2::VPC::Id'
 
-  DbSecurityGroupId:
-    Type: 'String'
-
-  DbPort:
-    Type: 'Number'
-    Default: 3306
-
   IdleTimeoutMinutes:
     Type: 'Number'
     Default: 15

--- a/templates/ecs-backend.yaml
+++ b/templates/ecs-backend.yaml
@@ -42,6 +42,16 @@ Parameters:
   AlbTargetGroupArn:
     Type: 'String'
 
+  CacheHost:
+    Type: 'String'
+
+  CachePort:
+    Type: 'String'
+
+  CacheConnectTimeout:
+    Type: 'Number'
+    Default: 10000 # 10 seconds
+
   CpuSize:
     Type: 'String'
     Default: '2048' # 2 vCPU
@@ -95,12 +105,42 @@ Parameters:
     Type: 'Number'
     Default: 180
 
+  NodeEnv:
+    Type: 'String'
+    Default: 'development'
+
+  BcryptSaltRounds:
+    Type: 'Number'
+    Default: 10
+
+  HashTokenSecret:
+    Type: 'String'
+
+  RestDataSourceCacheTtl:
+    Type: 'Number'
+    Default: 180 # 2 minutes
+
   JwtSecret:
     Type: 'String'
 
   JwtTtl:
+    Type: 'Number'
+    Default: 600 # 10 minutes
+
+  JwtRefreshSecret:
     Type: 'String'
-    Default: '1hr'
+
+  JwtRefreshTtl:
+    Type: 'Number'
+    Default: 86400 # 1 day
+
+  CsrfLength:
+    Type: 'Number'
+    Default: 32
+
+  CsrfTtl:
+    Type: 'Number'
+    Default: 3600 # 1 hour
 
   DbConnectionLimit:
     Type: 'Number'
@@ -137,11 +177,33 @@ Conditions:
   IsDev:
     !Equals [!Ref Env, 'dev']
 
+  IsSingleInstance:
+    !Equals [!Ref EcsDesiredServiceCount, 1]
+
 Resources:
   # -----------------------------------------------------------
   # Identitity and Access Management (IAM)
   #   See: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/AWS_IAM.html
   # -----------------------------------------------------------
+  # Policy to allow SSM Session Manager to access our ECS containers
+  SessionManagerPolicy:
+    Type: 'AWS::IAM::ManagedPolicy'
+    Properties:
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          Effect: 'Allow'
+          Action:
+            - 'ecs:ExecuteCommand'
+            - 'ssmmessages:CreateControlChannel'
+            - 'ssmmessages:CreateDataChannel'
+            - 'ssmmessages:OpenControlChannel'
+            - 'ssmmessages:OpenDataChannel'
+          Resource: '*'
+          Condition:
+            StringEquals:
+              "ecs:container-name": !Ref AppName
+
   # Role that grants our containers in the task permission to call AWS APIs
   EcsTaskRole:
     Type: 'AWS::IAM::Role'
@@ -162,10 +224,8 @@ Resources:
         - 'arn:aws:iam::aws:policy/AmazonRDSDataFullAccess'
         - 'arn:aws:iam::aws:policy/AmazonSESFullAccess'
         - 'arn:aws:iam::aws:policy/CloudWatchLogsFullAccess'
-
-
-        # - 'arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceRole'
-        # - 'arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role'
+        - 'arn:aws:iam::aws:policy/AmazonElastiCacheFullAccess'
+        - !Ref SessionManagerPolicy
 
   # -----------------------------------------------------------
   # Elastic Container Service (ECS) - Containers that host the application
@@ -218,7 +278,13 @@ Resources:
             # RDS port (The MySQL DB port)
             - ContainerPort: !Ref DbPort
               Protocol: 'tcp'
+            # Redis port
+            - ContainerPort: !Ref CachePort
+              Protocol: 'tcp'
           Environment:
+            - Name: 'NODE_ENV'
+              Value: !Ref NodeEnv
+
             - Name: 'LOG_LEVEL'
               Value: !Ref LogLevel
             - Name: 'USE_MOCK_DATA'
@@ -226,10 +292,33 @@ Resources:
 
             - Name: 'REST_DATA_SOURCE_CACHE_TTL'
               Value: !Ref RestDataSourceCacheTtl
+
+            - Name: 'BCRYPT_SALT_ROUNDS'
+              Value: !Ref BcryptSaltRounds
+            - Name: 'TOKEN_HASH_SECRET'
+              Value: !Ref HashTokenSecret
+
             - Name: 'JWT_SECRET'
               Value: !Ref JwtSecret
             - Name: 'JWT_TTL'
               Value: !Ref JwtTtl
+            - Name: 'JWT_REFRESH_SECRET'
+              Value: !Ref JwtRefreshSecret
+            - Name: 'JWT_REFRESH_TTL'
+              Value: !Ref JwtRefreshTtl
+
+            - Name: 'CSRF_LENGTH'
+              Value: !Ref CsrfLength
+            - Name: 'CSRF_TTL'
+              Value: !Ref CsrfTtl
+
+            # Elasticache Redis connection
+            - Name: 'CACHE_HOST'
+              Value: !Ref CacheHost
+            - Name: 'CACHE_PORT'
+              Value: !Ref CachePort
+            - Name: 'CACHE_CONNECT_TIMEOUT'
+              Value: !Ref CacheConnectTimeout
 
             - Name: 'DMP_ID_BASE_URL'
               Value: !Ref DmpIdBaseUrl
@@ -271,13 +360,10 @@ Resources:
       Cluster: !Ref EcsClusterId
       DesiredCount: !Ref EcsDesiredServiceCount
       EnableECSManagedTags: true
+      EnableExecuteCommand: true # Allow session manager
       HealthCheckGracePeriodSeconds: !Ref HealthCheckGracePeriod
       LaunchType: 'FARGATE'
       DeploymentConfiguration:
-        MinimumHealthPercent: !If
-          - IsDev
-          - !Ref AWS::NoValue
-          - !Ref MinimumHealthyContainerPercentage
         MaximumPercent: !Ref MaximumHealthyContainerPercentage
         DeploymentCircuitBreaker:
           Enable: true

--- a/templates/ecs-cluster.yaml
+++ b/templates/ecs-cluster.yaml
@@ -13,11 +13,16 @@ Parameters:
   DbSecurityGroupId:
     Type: 'String'
 
-  DbHost:
+  CacheSecurityGroupId:
     Type: 'String'
 
   DbPort:
     Type: 'String'
+    Default: '3006'
+
+  CachePort:
+    Type: 'String'
+    Default: '6379'
 
 Resources:
   # -----------------------------------------------------------
@@ -101,6 +106,30 @@ Resources:
       ToPort: !Ref DbPort
       GroupId: !GetAtt EcsSecurityGroup.GroupId
       DestinationSecurityGroupId: !Ref DbSecurityGroupId
+
+  # Allow the RDS instance(s) to receive traffic from the ECS instance(s)
+  CacheSecurityGroupIngressFromEcs:
+    Type: AWS::EC2::SecurityGroupIngress
+    DependsOn:
+      - EcsSecurityGroup
+    Properties:
+      IpProtocol: 'tcp'
+      FromPort: !Ref CachePort
+      ToPort: !Ref CachePort
+      GroupId: !Ref CacheSecurityGroupId
+      SourceSecurityGroupId: !GetAtt EcsSecurityGroup.GroupId
+
+  # Allow the RDS instance(s) to receive traffic from the ECS instance(s)
+  EcsSecurityGroupEgressToCache:
+    Type: AWS::EC2::SecurityGroupEgress
+    DependsOn:
+      - EcsSecurityGroup
+    Properties:
+      IpProtocol: 'tcp'
+      FromPort: !Ref CachePort
+      ToPort: !Ref CachePort
+      GroupId: !GetAtt EcsSecurityGroup.GroupId
+      DestinationSecurityGroupId: !Ref CacheSecurityGroupId
 
   # -----------------------------------------------------------
   # Elastic Container Service (ECS) - Containers that host the application

--- a/templates/ecs-frontend.yaml
+++ b/templates/ecs-frontend.yaml
@@ -108,6 +108,25 @@ Resources:
   # Identitity and Access Management (IAM)
   #   See: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/AWS_IAM.html
   # -----------------------------------------------------------
+  # Policy to allow SSM Session Manager to access our ECS containers
+  SessionManagerPolicy:
+    Type: 'AWS::IAM::ManagedPolicy'
+    Properties:
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          Effect: 'Allow'
+          Action:
+            - 'ecs:ExecuteCommand'
+            - 'ssmmessages:CreateControlChannel'
+            - 'ssmmessages:CreateDataChannel'
+            - 'ssmmessages:OpenControlChannel'
+            - 'ssmmessages:OpenDataChannel'
+          Resource: '*'
+          Condition:
+            StringEquals:
+              "ecs:container-name": !Ref AppName
+
   # Role that grants our containers in the task permission to call AWS APIs
   EcsTaskRole:
     Type: 'AWS::IAM::Role'
@@ -126,6 +145,7 @@ Resources:
         - 'arn:aws:iam::aws:policy/AmazonS3FullAccess'
         - 'arn:aws:iam::aws:policy/AmazonSESFullAccess'
         - 'arn:aws:iam::aws:policy/CloudWatchLogsFullAccess'
+        - !Ref SessionManagerPolicy
 
   # -----------------------------------------------------------
   # Elastic Container Service (ECS) - Containers that host the application
@@ -199,6 +219,7 @@ Resources:
       Cluster: !Ref EcsClusterId
       DesiredCount: !Ref EcsDesiredServiceCount
       EnableECSManagedTags: true
+      EnableExecuteCommand: true # Allow session manager
       HealthCheckGracePeriodSeconds: !Ref HealthCheckGracePeriod
       LaunchType: 'FARGATE'
       DeploymentConfiguration:

--- a/templates/redis.yaml
+++ b/templates/redis.yaml
@@ -1,0 +1,68 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: 'Redis Cache for the Apollo server'
+
+Parameters:
+  VpcId:
+    Type: 'AWS::EC2::VPC::Id'
+
+  Subnets:
+    Type: 'List<AWS::EC2::Subnet::Id>'
+
+  Env:
+    Type: 'String'
+    Default: 'dev'
+
+  CachePort:
+    Type: 'Number'
+    Default: 6379
+
+Resources:
+  RedisCacheSecurityGroup:
+    Type: 'AWS::EC2::SecurityGroup'
+    Properties:
+      GroupDescription: !Sub "${AWS::StackName} Redis cache SecGrp"
+      GroupName: !Sub "${AWS::StackName}-RedisSecGrp"
+      VpcId: !Ref VpcId
+
+  RedisCacheSecurityGroupIngress:
+    Type: 'AWS::EC2::SecurityGroupIngress'
+    Properties:
+      GroupId: !GetAtt RedisCacheSecurityGroup.GroupId
+      IpProtocol: 'tcp'
+      FromPort: !Ref CachePort
+      ToPort: !Ref CachePort
+      SourceSecurityGroupId: !GetAtt RedisCacheSecurityGroup.GroupId
+
+  RedisCache:
+    Type: 'AWS::ElastiCache::ServerlessCache'
+    Properties:
+      Engine: 'redis'
+      SecurityGroupIds:
+        - !GetAtt RedisCacheSecurityGroup.GroupId
+      ServerlessCacheName: !Sub "dmptool-${Env}-redis"
+      SubnetIds: !Ref Subnets
+
+Outputs:
+  RedisCacheSecurityGroupID:
+    Value: !GetAtt RedisCacheSecurityGroup.GroupId
+
+  RedisName:
+    Value: !Ref RedisCache
+
+  RedisArn:
+    Value: !GetAtt RedisCache.ARN
+
+  RedisEngineVersion:
+    Value: !GetAtt RedisCache.FullEngineVersion
+
+  RedisCacheHost:
+    Value: !GetAtt RedisCache.Endpoint.Address
+
+  RedisCachePort:
+    Value: !GetAtt RedisCache.Endpoint.Port
+
+  RedisReaderHost:
+    Value: !GetAtt RedisCache.ReaderEndpoint.Address
+
+  RedisReaderPort:
+    Value: !GetAtt RedisCache.ReaderEndpoint.Port


### PR DESCRIPTION
Fixes #82 

- Added `redis.yaml` template and `redis-backend.yaml` Sceptre config
- Added Session Manager policies for `ecs-frontend` and `ecs-backend` so that we can connect to containers
- Updated the `ecs-backend.yaml` Sceptre config and template to include the Redis ElastiCache Host and Port and also a bunch of new bcrypt, crypto, NODE_ENV and jwt ENV variables
- Updated the `ecs-cluster.yaml` so that it has the Redis port and attaches to the Redis Security Group
- Updated the `ecs-backend.yaml` and `ecs-frontend.yaml` to have a minimum of 2 containers
- Updated the `initial_setup.rb` script so that the JWT refresh token secret and Cache hash secret can be specified (updated the Wiki documentation as well)
- Updated the `alb.yaml` with the new refresh, signout and csrf backend endpoints
- Removed the RDS SecGrp and Port from the Cloud9 template as it was not necessary
- Removed OAuth2 endpoints since we removed that from the backend for now