### PR TITLE
Correct env variable definitions in ecs-frontend.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
 - Updated the `initial_setup.rb` script so that the JWT refresh token secret and Cache hash secret can be specified (updated the Wiki documentation as well)
 - Updated the `alb.yaml` with the new refresh, signout and csrf backend endpoints
 
+### Fixed
+- Corrected ways that env variables defined in `config/regional/ecs-frontend.yaml` file
+
 ## v1.4.4
 
 ### Added

--- a/config/dev/regional/ecs-frontend.yaml
+++ b/config/dev/regional/ecs-frontend.yaml
@@ -40,8 +40,8 @@ parameters:
 
   LogLevel: 'debug'
 
-  NextPublicBaseUrl: ="https://ui.dmphub.uc3dev.cdlib.net"
-  NextPublicServerEndpoint: ="https://ui.dmphub.uc3dev.cdlib.net"
-  NextPublicGraphqlServerEndpoint: ="https://ui.dmphub.uc3dev.cdlib.net/graphql"
+  NextPublicBaseUrl: https://ui.dmphub.uc3dev.cdlib.net
+  NextPublicServerEndpoint: https://ui.dmphub.uc3dev.cdlib.net
+  NextPublicGraphqlServerEndpoint: https://ui.dmphub.uc3dev.cdlib.net/graphql
 
   HelpdeskEmail: !ssm /uc3/dmsp/prototype/dev/HelpdeskEmail


### PR DESCRIPTION
Fixed ([#182](https://github.com/CDLUC3/dmsp_aws_prototype/issues/182))

Currently, the ecs-frontend template includes several environment variables:
```
            - Name: 'NEXT_PUBLIC_BASE_URL'
              Value: !Ref NextPublicBaseUrl
            - Name: 'NEXT_PUBLIC_SERVER_ENDPOINT'
              Value: !Ref NextPublicServerEndpoint
            - Name: 'NEXT_PUBLIC_GRAPHQL_SERVER_ENDPOINT'
              Value: !Ref NextPublicGraphqlServerEndpoint
```
Currently, the env variables in my local .env.local file, are defined as:
```
NEXT_PUBLIC_BASE_URL="http://localhost:3000"
NEXT_PUBLIC_SERVER_ENDPOINT="http://localhost:4000"
NEXT_PUBLIC_GRAPHQL_SERVER_ENDPOINT="http://localhost:4000/graphql"
```

The variables in ecs-frontend config were erroneously defined to include = signs, and it's throwing off the url, so that it is coming through as https://ui.dmphub.uc3dev.cdlib.net/=%22https://ui.dmphub.uc3dev.cdlib.net%22/apollo-csrf in the request. Will remove the = sign and the double quotes.

I didn't need to add any new env variables at this time.
