### PR TITLE
Add an API client account for COKI

### DIFF
--- a/config/dev/regional/api-clients/coki.yaml
+++ b/config/dev/regional/api-clients/coki.yaml
@@ -1,0 +1,32 @@
+template:
+  path: 'cognito-app-client.yaml'
+  type: 'file'
+
+parameters:
+  UserPoolId: !stack_output dev/regional/cognito.yaml::UserPoolId
+
+  Domain: !stack_attr sceptre_user_data.domain
+  Subdomain: 'auth'
+  Env: !stack_attr sceptre_user_data.env
+
+  ClientName: 'coki'
+
+  ClientCallbackUri: 'https://localhost:3000/callback'
+
+  OnlyAllowAdminsToCreateUsers: 'false'
+  UnusedAccountValidityDays: '14'
+  MinimumPasswordLength: '8'
+
+  TokenValidityUnits: 'minutes'
+  AccessTokenValidity: '10'
+  AuthSessionValidatyMinutes: '3'
+  IdTokenValidity: '7'
+  RefreshTokenValidity: '10080'
+
+  Scopes:
+    - 'https://auth.dmphub.uc3dev.cdlib.net/dev.data-transfer'
+
+hooks:
+  after_update:
+    cmd: 'src/add-api-client.sh dev coki http://localhost:3000/callback'
+    cmd: 'aws ssm put-parameter --overwrite --name /uc3/dmp/tool/provenance/coki/ror_list --type String --value "[]"'

--- a/config/dev/regional/api_clients/coki.yaml
+++ b/config/dev/regional/api_clients/coki.yaml
@@ -9,11 +9,7 @@ parameters:
   Subdomain: 'auth'
   Env: !stack_attr sceptre_user_data.env
 
-  ClientName: 'uc-riverside'
-
-  Scopes:
-    - 'https://auth.dmphub.uc3prd.cdlib.net/prd.read'
-    - 'https://auth.dmphub.uc3prd.cdlib.net/prd.write'
+  ClientName: 'coki'
 
   ClientCallbackUri: 'https://localhost:3000/callback'
 
@@ -27,7 +23,11 @@ parameters:
   IdTokenValidity: '7'
   RefreshTokenValidity: '10080'
 
+  Scopes:
+    Scopes:
+    - 'https://auth.dmphub.uc3dev.cdlib.net/prd.data-transfer'
+
 hooks:
   after_update:
-    cmd: 'src/add-api-client.sh prd uc-riverside http://localhost:3000/callback'
-    cmd: 'aws ssm put-parameter --overwrite --name /uc3/dmp/tool/provenance/uc-riverside/ror_list --type String --value "[\"https://ror.org/03nawhv43\"]"'
+    cmd: 'src/add-api-client.sh dev coki http://localhost:3000/callback'
+    cmd: 'aws ssm put-parameter --overwrite --name /uc3/dmp/tool/provenance/coki/ror_list --type String --value "[]"'

--- a/config/prd/regional/api-clients/arizona-state.yaml
+++ b/config/prd/regional/api-clients/arizona-state.yaml
@@ -13,7 +13,9 @@ parameters:
 
   ClientCallbackUri: 'https://localhost:3000/callback/'
 
-  AllowWrite: 'yes'
+  Scopes:
+    - 'https://auth.dmphub.uc3prd.cdlib.net/prd.read'
+    - 'https://auth.dmphub.uc3prd.cdlib.net/prd.write'
 
   OnlyAllowAdminsToCreateUsers: 'false'
   UnusedAccountValidityDays: '14'

--- a/config/prd/regional/api-clients/coki.yaml
+++ b/config/prd/regional/api-clients/coki.yaml
@@ -1,0 +1,33 @@
+template:
+  path: 'cognito-app-client.yaml'
+  type: 'file'
+
+parameters:
+  UserPoolId: !stack_output prd/regional/cognito.yaml::UserPoolId
+
+  Domain: !stack_attr sceptre_user_data.domain
+  Subdomain: 'auth'
+  Env: !stack_attr sceptre_user_data.env
+
+  ClientName: 'coki'
+
+  ClientCallbackUri: 'https://localhost:3000/callback'
+
+  OnlyAllowAdminsToCreateUsers: 'false'
+  UnusedAccountValidityDays: '14'
+  MinimumPasswordLength: '8'
+
+  TokenValidityUnits: 'minutes'
+  AccessTokenValidity: '10'
+  AuthSessionValidatyMinutes: '3'
+  IdTokenValidity: '7'
+  RefreshTokenValidity: '10080'
+
+  Scopes:
+    Scopes:
+    - 'https://auth.dmphub.uc3prd.cdlib.net/prd.data-transfer'
+
+hooks:
+  after_update:
+    cmd: 'src/add-api-client.sh prd coki http://localhost:3000/callback'
+    cmd: 'aws ssm put-parameter --overwrite --name /uc3/dmp/tool/provenance/coki/ror_list --type String --value "[]"'

--- a/config/prd/regional/api-clients/coki.yaml
+++ b/config/prd/regional/api-clients/coki.yaml
@@ -24,7 +24,6 @@ parameters:
   RefreshTokenValidity: '10080'
 
   Scopes:
-    Scopes:
     - 'https://auth.dmphub.uc3prd.cdlib.net/prd.data-transfer'
 
 hooks:

--- a/config/prd/regional/api-clients/stanford.yaml
+++ b/config/prd/regional/api-clients/stanford.yaml
@@ -13,7 +13,9 @@ parameters:
 
   ClientCallbackUri: 'https://localhost:3000/callback'
 
-  AllowWrite: 'yes'
+  Scopes:
+    - 'https://auth.dmphub.uc3prd.cdlib.net/prd.read'
+    - 'https://auth.dmphub.uc3prd.cdlib.net/prd.write'
 
   OnlyAllowAdminsToCreateUsers: 'false'
   UnusedAccountValidityDays: '14'

--- a/config/prd/regional/api-clients/uc-boulder.yaml
+++ b/config/prd/regional/api-clients/uc-boulder.yaml
@@ -11,6 +11,10 @@ parameters:
 
   ClientName: 'uc-boulder'
 
+  Scopes:
+    - 'https://auth.dmphub.uc3prd.cdlib.net/prd.read'
+    - 'https://auth.dmphub.uc3prd.cdlib.net/prd.write'
+
   ClientCallbackUri: 'https://localhost:3000/callback'
 
   OnlyAllowAdminsToCreateUsers: 'false'

--- a/config/stg/regional/api-clients/coki.yaml
+++ b/config/stg/regional/api-clients/coki.yaml
@@ -3,7 +3,7 @@ template:
   type: 'file'
 
 parameters:
-  UserPoolId: !stack_output prd/regional/cognito.yaml::UserPoolId
+  UserPoolId: !stack_output stg/regional/cognito.yaml::UserPoolId
 
   Domain: !stack_attr sceptre_user_data.domain
   Subdomain: 'auth'
@@ -25,9 +25,9 @@ parameters:
 
   Scopes:
     Scopes:
-    - 'https://auth.dmphub.uc3dev.cdlib.net/prd.data-transfer'
+    - 'https://auth.dmphub.uc3stg.cdlib.net/stg.data-transfer'
 
 hooks:
   after_update:
-    cmd: 'src/add-api-client.sh dev coki http://localhost:3000/callback'
+    cmd: 'src/add-api-client.sh stg coki http://localhost:3000/callback'
     cmd: 'aws ssm put-parameter --overwrite --name /uc3/dmp/tool/provenance/coki/ror_list --type String --value "[]"'

--- a/config/stg/regional/api-clients/coki.yaml
+++ b/config/stg/regional/api-clients/coki.yaml
@@ -24,7 +24,6 @@ parameters:
   RefreshTokenValidity: '10080'
 
   Scopes:
-    Scopes:
     - 'https://auth.dmphub.uc3stg.cdlib.net/stg.data-transfer'
 
 hooks:

--- a/templates/cognito-app-client.yaml
+++ b/templates/cognito-app-client.yaml
@@ -22,6 +22,9 @@ Parameters:
   ClientCallbackUri:
     Type: 'String'
 
+  Scopes:
+    Type: 'List<String>'
+
   OnlyAllowAdminsToCreateUsers:
     Type: 'String'
     Default: 'false'
@@ -62,17 +65,6 @@ Parameters:
     Type: 'Number'
     Default: 10080 # 7 days
 
-  AllowWrite:
-    Type: 'String'
-    Default: 'no'
-    AllowedValues:
-      - 'yes'
-      - 'no'
-
-Conditions:
-  WriteAllowed:
-    !Equals [!Ref AllowWrite, 'yes']
-
 Resources:
   # --------------------------------------------------------------
   # Cognito UserPool application clients
@@ -92,13 +84,7 @@ Resources:
       AllowedOAuthFlowsUserPoolClient: true
       AllowedOAuthFlows:
         - 'client_credentials'
-      AllowedOAuthScopes: !If
-        - WriteAllowed
-        # Allow both read and write
-        - - !Sub 'https://${Subdomain}.${Domain}/${Env}.read'
-          - !Sub 'https://${Subdomain}.${Domain}/${Env}.write'
-        # Only allow read
-        - - !Sub 'https://${Subdomain}.${Domain}/${Env}.read'
+      AllowedOAuthScopes: !Ref Scopes
       EnableTokenRevocation: true
       PreventUserExistenceErrors: 'ENABLED'
       GenerateSecret: true

--- a/templates/cognito.yaml
+++ b/templates/cognito.yaml
@@ -250,7 +250,6 @@ Resources:
         - !Sub 'https://${Subdomain}.${Domain}/${Env}.read'
         - !Sub 'https://${Subdomain}.${Domain}/${Env}.upload'
         - !Sub 'https://${Subdomain}.${Domain}/${Env}.write'
-        - !Sub 'https://${Subdomain}.${Domain}/${Env}.data-transfer'
       EnableTokenRevocation: true
       PreventUserExistenceErrors: 'ENABLED'
       GenerateSecret: true

--- a/templates/cognito.yaml
+++ b/templates/cognito.yaml
@@ -250,6 +250,7 @@ Resources:
         - !Sub 'https://${Subdomain}.${Domain}/${Env}.read'
         - !Sub 'https://${Subdomain}.${Domain}/${Env}.upload'
         - !Sub 'https://${Subdomain}.${Domain}/${Env}.write'
+        - !Sub 'https://${Subdomain}.${Domain}/${Env}.data-transfer'
       EnableTokenRevocation: true
       PreventUserExistenceErrors: 'ENABLED'
       GenerateSecret: true

--- a/templates/cognito.yaml
+++ b/templates/cognito.yaml
@@ -174,6 +174,8 @@ Resources:
           ScopeDescription: 'Allows access to the POST api endpoint for uploading PDF narratives'
         - ScopeName: !Sub '${Env}.write'
           ScopeDescription: 'Allows access to POST, PUT for DMPs (e.g. postDmp, putDmp, deleteDmp)'
+        - ScopeName: !Sub '${Env}.data-transfer'
+          ScopeDescription: 'Allows access to the GET and PUT endpoints for exchanging metadata files'
 
   UserPoolDomain:
     Type: 'AWS::Cognito::UserPoolDomain'


### PR DESCRIPTION
Add a Cognito App Client for COKI to use to access the API.

AWS auto-generates the ClientId and ClientSecret upon creation. Those credentials then need to be shared with COKI so they can access the API.

They have been given access to the `transfer-data` scope initially so that they can get/put files into the new FileExchange S3 bucket (added in PR #184) using pre-signed URLs provided by the new `dmps/downloads` endpoint(s) in the dmsp_api_prototype repo's [PR #27](https://github.com/CDLUC3/dmsp_api_prototype/pull/27/files)